### PR TITLE
fixed address range typo

### DIFF
--- a/gb-emu-lib/MMU.cpp
+++ b/gb-emu-lib/MMU.cpp
@@ -205,7 +205,7 @@ bool MMU::WriteByte(const ushort& address, const byte val)
     {
         m_bank0[address - 0xC000] = val;
     }
-    else if (address >= 0xC000 && address <= 0xDFFF)
+    else if (address >= 0xD000 && address <= 0xDFFF)
     {
         m_bank1[address - 0xD000] = val;
     }

--- a/gb-emu-lib/MMU.cpp
+++ b/gb-emu-lib/MMU.cpp
@@ -156,7 +156,7 @@ byte MMU::ReadByte(const ushort& address)
     {
         return m_bank0[address - 0xC000];
     }
-    else if (address >= 0xC000 && address <= 0xDFFF)
+    else if (address >= 0xD000 && address <= 0xDFFF)
     {
         return m_bank1[address - 0xD000];
     }


### PR DESCRIPTION
In the ReadByte and WriteByte functions (MMU.cpp), the addressable range of Bank 1 should be 0xD000 to 0xDFFF.